### PR TITLE
[bitnami/spring-cloud-dataflow] Fixing disabling networkPolicy creation

### DIFF
--- a/bitnami/spring-cloud-dataflow/templates/skipper/networkpolicy.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/networkpolicy.yaml
@@ -3,7 +3,7 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if or .Values.skipper.enabled .Values.skipper.networkPolicy.enabled }}
+{{- if and .Values.skipper.enabled .Values.skipper.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:


### PR DESCRIPTION
### Description of the change

This PR fixes disabling the creation of networkPolicy when we set `networkPolicy.enabled` to `false`.
In my case I want to deploy Spring Cloud Skipper and not create a networkPolicy.

I noticed that when I have (by default) skipper.enabled set to true then by default a networkPolicy is created.
When You add networkPolicy.enabled false, then the networkPolicy is still being created because of the bug in networkpolicy template.

I was using SpringCloudDataFlow HelmChart in 2 versions:
- 23.1.4
- 26.5.3
In both cases the results were the same.

### Benefits

It should be possible to disable creation of networkPolicy.

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)